### PR TITLE
fix: agent loop does not break

### DIFF
--- a/src/rai/scenario_engine/scenario_engine.py
+++ b/src/rai/scenario_engine/scenario_engine.py
@@ -169,9 +169,13 @@ class ScenarioRunner:
                     self.history = run_requested_tools(
                         ai_msg, self.tools, self.history, llm_type=self.llm_type
                     )
+                    break_loop = False
                     for tool_call in ai_msg.tool_calls:
                         if tool_call["name"] == msg.stop_action:
+                            break_loop = True
                             break
+                    if break_loop:
+                        break
             elif isinstance(msg, ConditionalScenario):
                 new_scenario = msg(self.history)
                 self._run(new_scenario)


### PR DESCRIPTION
Before:
```
python examples/husarion_poc_example.py 
Running tool: PlayVoiceMessageTool with args: {'content': 'I am accessing the camera feed to understand the surroundings and will add waypoints based on my observations.'}
Running tool: GetCameraImageTool with args: {'topic': '/camera/camera/color/image_raw'}
2024-07-02 14:25:05 robo-pc-054 SingleImageGrabber[2411715] ERROR Failed to receive message of type Metaclass_Image from topic /camera/camera/color/image_raw
Running tool: PlayVoiceMessageTool with args: {'content': 'There was an issue accessing the camera feed. I will retry.'}
Running tool: WaitForSecondsTool with args: {'seconds': 5}
Running tool: GetCameraImageTool with args: {'topic': '/camera/camera/color/image_raw'}
2024-07-02 14:25:23 robo-pc-054 SingleImageGrabber[2411715] ERROR Failed to receive message of type Metaclass_Image from topic /camera/camera/color/image_raw
Running tool: PlayVoiceMessageTool with args: {'content': 'I am unable to access the camera feed at the moment. Please check the camera connection and try again.'}
Running tool: FinishTool with args: {}
Running tool: PlayVoiceMessageTool with args: {'content': 'I will continue the mission by using available tools to navigate and add waypoints.'}
Running tool: GetCurrentPositionTool with args: {}
```
After:
```
python examples/husarion_poc_example.py 
Running tool: PlayVoiceMessageTool with args: {'content': 'I will now use the camera to understand the surroundings and add waypoints based on observations.'}
Running tool: GetCameraImageTool with args: {'topic': '/camera/camera/color/image_raw'}
2024-07-02 14:21:11 robo-pc-054 SingleImageGrabber[2407219] ERROR Failed to receive message of type Metaclass_Image from topic /camera/camera/color/image_raw
Running tool: PlayVoiceMessageTool with args: {'content': 'There was an issue accessing the camera feed. I will try again.'}
Running tool: GetCameraImageTool with args: {'topic': '/camera/camera/color/image_raw'}
2024-07-02 14:21:23 robo-pc-054 SingleImageGrabber[2407219] ERROR Failed to receive message of type Metaclass_Image from topic /camera/camera/color/image_raw
Running tool: PlayVoiceMessageTool with args: {'content': 'The camera feed is still inaccessible. I will need to investigate further.'}
Running tool: Ros2TopicTool with args: {'command': 'list'}
Running tool: PlayVoiceMessageTool with args: {'content': 'The camera topic is not available. Please check the camera connection and try again.'}
Running tool: FinishTool with args: {}
```