### PR TITLE
docs: fix redis docker image name

### DIFF
--- a/docs/vendors.md
+++ b/docs/vendors.md
@@ -51,7 +51,7 @@ export REDIS_CACHE_HOST="redis://<host>"
 Self hosting Redis:
 
 ```bash
-docker run -p 6379:6379 -d redis/redis:latest
+docker run -p 6379:6379 -d redis:latest
 export REDIS_CACHE_HOST="redis://localhost:6379"
 ```
 


### PR DESCRIPTION
docker pull redis/redis:lastest does not work, becuase such image does not exist.
