### PR TITLE
fix(tools): reject non-positive WaitForSecondsTool delays

### DIFF
--- a/src/rai_core/rai/tools/time.py
+++ b/src/rai_core/rai/tools/time.py
@@ -41,6 +41,16 @@ class WaitForSecondsTool(BaseTool):
 
     def _run(self, seconds: int):
         """Waits for the specified number of seconds."""
+        # bool is a subclass of int; reject it so True/False never sleep.
+        if isinstance(seconds, bool) or not isinstance(seconds, int):
+            raise ValueError(
+                "WaitForSecondsTool requires a positive integer number of seconds"
+            )
+        if seconds <= 0:
+            raise ValueError(
+                "WaitForSecondsTool requires a positive number of seconds "
+                f"(got {seconds})"
+            )
         if seconds > 10:
             seconds = 10
         time.sleep(seconds)

--- a/tests/tools/test_wait_for_seconds_tool.py
+++ b/tests/tools/test_wait_for_seconds_tool.py
@@ -25,3 +25,34 @@ def test_wait_for_seconds_tool_caps_duration():
 
     mock_sleep.assert_called_once_with(10)
     assert result == "Waited for 10 seconds."
+
+
+def test_wait_for_seconds_tool_happy_path():
+    tool = WaitForSecondsTool()
+    with patch("rai.tools.time.time.sleep") as mock_sleep:
+        result = tool._run(3)
+    mock_sleep.assert_called_once_with(3)
+    assert result == "Waited for 3 seconds."
+
+
+def test_wait_for_seconds_tool_rejects_non_positive():
+    tool = WaitForSecondsTool()
+    for bad in (0, -3):
+        with patch("rai.tools.time.time.sleep") as mock_sleep:
+            try:
+                tool._run(bad)
+                raise AssertionError(f"expected ValueError for {bad}")
+            except ValueError as exc:
+                assert "positive" in str(exc).lower()
+            mock_sleep.assert_not_called()
+
+
+def test_wait_for_seconds_tool_rejects_bool():
+    tool = WaitForSecondsTool()
+    with patch("rai.tools.time.time.sleep") as mock_sleep:
+        try:
+            tool._run(True)  # type: ignore[arg-type]
+            raise AssertionError("expected ValueError for bool")
+        except ValueError:
+            pass
+        mock_sleep.assert_not_called()


### PR DESCRIPTION
## Purpose
`WaitForSecondsTool` capped upper waits at 10s but still accepted non-positive values (and bools, since `bool` subclasses `int`), which agents could pass through to `time.sleep`.

## Proposed Changes
- Reject non-`int` / `bool` and `seconds <= 0` with `ValueError`.
- Preserve max 10s clamp and message after successful wait.
- Unit tests for happy path, cap, zero/negative, bool.

## Testing
- `tests/tools/test_wait_for_seconds_tool.py` (sleep mocked).
- Spec: `specs/rai/2026-07-15-2.md` (aerial dual-agent; Grok-spec + Bartok review micro-diff).

## Duplicate check
No open PR for WaitForSecondsTool non-positive validation.