### PR TITLE
fix(tools): reject non-positive timeout decorator seconds

### DIFF
--- a/src/rai_core/rai/tools/timeout.py
+++ b/src/rai_core/rai/tools/timeout.py
@@ -34,10 +34,25 @@ Alternatives considered:
 """
 
 import concurrent.futures
+import math
 from functools import wraps
 from typing import Any, Callable, TypeVar
 
 F = TypeVar("F", bound=Callable[..., Any])
+
+
+
+def _normalize_timeout_seconds(seconds: float) -> float:
+    """Return a positive finite timeout duration or raise ValueError."""
+    try:
+        seconds_f = float(seconds)
+    except (TypeError, ValueError) as err:
+        raise ValueError(
+            "timeout seconds must be a positive finite number"
+        ) from err
+    if not math.isfinite(seconds_f) or seconds_f <= 0:
+        raise ValueError("timeout seconds must be a positive finite number")
+    return seconds_f
 
 
 class RaiTimeoutError(Exception):
@@ -53,7 +68,7 @@ def timeout(seconds: float, timeout_message: str | None = None) -> Callable[[F],
     Parameters
     ----------
     seconds : float
-        Timeout duration in seconds
+        Timeout duration in seconds (must be positive and finite)
     timeout_message : str, optional
         Custom timeout message. If not provided, a default message will be used.
 
@@ -64,6 +79,8 @@ def timeout(seconds: float, timeout_message: str | None = None) -> Callable[[F],
 
     Raises
     ------
+    ValueError
+        If ``seconds`` is not a positive finite number
     RaiTimeoutError
         When the decorated function exceeds the specified timeout
 
@@ -80,6 +97,7 @@ def timeout(seconds: float, timeout_message: str | None = None) -> Callable[[F],
     ... except RaiTimeoutError as e:
     ...     print(f"Timeout: {e}")
     """
+    seconds = _normalize_timeout_seconds(seconds)
 
     def decorator(func: F) -> F:
         @wraps(func)
@@ -112,7 +130,7 @@ def timeout_method(
     Parameters
     ----------
     seconds : float
-        Timeout duration in seconds
+        Timeout duration in seconds (must be positive and finite)
     timeout_message : str, optional
         Custom timeout message. If not provided, a default message will be used.
 
@@ -123,6 +141,8 @@ def timeout_method(
 
     Raises
     ------
+    ValueError
+        If ``seconds`` is not a positive finite number
     RaiTimeoutError
         When the decorated method exceeds the specified timeout
 
@@ -141,6 +161,7 @@ def timeout_method(
     ... except RaiTimeoutError as e:
     ...     print(f"Timeout: {e}")
     """
+    seconds = _normalize_timeout_seconds(seconds)
 
     def decorator(func: F) -> F:
         @wraps(func)

--- a/tests/tools/test_timeout.py
+++ b/tests/tools/test_timeout.py
@@ -59,3 +59,21 @@ def test_timeout_method_raises_timeout_error(obj):
     with pytest.raises(RaiTimeoutError) as exc_info:
         obj.slow_method_custom()
     assert str(exc_info.value) == "Custom timeout message"
+
+
+def test_timeout_rejects_non_positive():
+    import pytest
+    from rai.tools.timeout import timeout, timeout_method
+
+    for bad in (0, -1.0, float("nan")):
+        with pytest.raises(ValueError):
+            @timeout(bad)
+            def _fn():
+                return None
+
+        with pytest.raises(ValueError):
+            class _C:
+                @timeout_method(bad)
+                def m(self):
+                    return None
+


### PR DESCRIPTION
## Summary
- `timeout` / `timeout_method` accepted 0, negatives, and non-finite values
- Normalize and validate at decorate time; raise ValueError if not positive finite
- Existing RaiTimeoutError behavior for runtime timeouts unchanged

## Test plan
- Offline importlib validation of decorator configure failures
- Extended tests/tools/test_timeout.py for 0 / -1 / NaN

Spec: aerial specs/rai/2026-07-16-2.md
