### PR TITLE
fix(ros2): reject non-positive LlmRosoutParser bufsize

### DIFF
--- a/src/rai_core/rai/communication/ros2/ros_logs.py
+++ b/src/rai_core/rai/communication/ros2/ros_logs.py
@@ -94,6 +94,13 @@ class RaiStateLogsParser(BaseLogsParser):
         return "\n".join(response.string_list)
 
 
+def validate_bufsize(bufsize: int) -> int:
+    """Return bufsize if positive; raise ValueError otherwise."""
+    if bufsize <= 0:
+        raise ValueError(f"bufsize must be positive, got {bufsize!r}")
+    return bufsize
+
+
 class LlmRosoutParser(BaseLogsParser):
     """Bufferize `/rosout` and summarize is with LLM"""
 
@@ -104,7 +111,7 @@ class LlmRosoutParser(BaseLogsParser):
         callback_group: rclpy.callback_groups.CallbackGroup,
         bufsize: int = 100,
     ):
-        self.bufsize = bufsize
+        self.bufsize = validate_bufsize(bufsize)
         self._buffer: Deque[str] = deque()
         self.template = ChatPromptTemplate.from_messages(
             [

--- a/tests/communication/test_ros_logs_parser.py
+++ b/tests/communication/test_ros_logs_parser.py
@@ -1,0 +1,53 @@
+# Copyright (C) 2025 Robotec.AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Offline tests for ros_logs bufsize validation (no rclpy import)."""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+ROS_LOGS = REPO / "src/rai_core/rai/communication/ros2/ros_logs.py"
+
+
+def _load_validate_bufsize():
+    """Load validate_bufsize via AST exec of the pure function only."""
+    source = ROS_LOGS.read_text()
+    module = ast.parse(source)
+    fn = None
+    for node in module.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "validate_bufsize":
+            fn = node
+            break
+    assert fn is not None, "validate_bufsize must exist in ros_logs.py"
+    code = compile(ast.Module(body=[fn], type_ignores=[]), str(ROS_LOGS), "exec")
+    ns: dict = {}
+    exec(code, ns)
+    return ns["validate_bufsize"]
+
+
+validate_bufsize = _load_validate_bufsize()
+
+
+@pytest.mark.parametrize("bad", [0, -1, -100])
+def test_validate_bufsize_rejects_nonpositive(bad):
+    with pytest.raises(ValueError, match="bufsize must be positive"):
+        validate_bufsize(bad)
+
+
+def test_validate_bufsize_accepts_positive():
+    assert validate_bufsize(1) == 1
+    assert validate_bufsize(100) == 100


### PR DESCRIPTION
## Summary
`LlmRosoutParser` treated any `bufsize` as valid. Values ≤ 0 make the ring buffer ill-defined (every line dropped after append, or never shed). This PR validates **`bufsize > 0`** at construction via a small pure helper and rejects bad sizes with `ValueError`.

## Motivation
Fail closed early with a clear error instead of silent broken buffering for agent log digests.

## Changes
- `validate_bufsize()` + use in `LlmRosoutParser.__init__`
- Offline unit tests (no ROS runtime required)

## Verification
```bash
PYTHONPATH=src/rai_core python3 -m pytest tests/communication/test_ros_logs_parser.py -q
# 4 passed
```

AI-assisted; human-reviewed.