### PR TITLE
fix(communication): reject non-positive action send_goal timeout_sec

### DIFF
--- a/src/rai_core/rai/communication/ros2/api/action.py
+++ b/src/rai_core/rai/communication/ros2/api/action.py
@@ -59,6 +59,18 @@ from rai.communication.ros2.api.conversion import import_message_from_str
 from rai.communication.ros2.ros_async import get_future_result
 
 
+
+def _require_positive_timeout(timeout_sec: float, *, name: str = "timeout_sec") -> float:
+    """Fail closed: timeout must be a finite number > 0 (bool is rejected)."""
+    if isinstance(timeout_sec, bool) or not isinstance(timeout_sec, (int, float)):
+        raise TypeError(
+            f"{name} must be a positive number, got {type(timeout_sec).__name__}"
+        )
+    if timeout_sec <= 0:
+        raise ValueError(f"{name} must be positive, got {timeout_sec!r}")
+    return float(timeout_sec)
+
+
 class ROS2ActionData(TypedDict):
     action_client: Optional[ActionClient]
     goal_future: Optional[rclpy.task.Future]
@@ -202,6 +214,7 @@ class ROS2ActionAPI(BaseROS2API):
         ] = lambda _: None,  # TODO: handle done callback
         timeout_sec: float = 1.0,
     ) -> Tuple[bool, Annotated[str, "action handle"]]:
+        _require_positive_timeout(timeout_sec)
         handle = self._generate_handle()
         self.actions[handle] = ROS2ActionData(
             action_client=None,

--- a/tests/communication_offline/test_action_timeout_validate.py
+++ b/tests/communication_offline/test_action_timeout_validate.py
@@ -1,0 +1,63 @@
+# Copyright (C) 2026 Robotec.AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Offline unit tests for send_goal timeout validation helper text in action.py.
+
+These tests re-bind the same predicate as ``_require_positive_timeout`` in
+``rai.communication.ros2.api.action`` without importing rclpy.
+"""
+
+from pathlib import Path
+
+import pytest
+
+
+def _load_helper():
+    path = (
+        Path(__file__).resolve().parents[2]
+        / "src/rai_core/rai/communication/ros2/api/action.py"
+    )
+    text = path.read_text()
+    start = text.index("def _require_positive_timeout")
+    # find end at next top-level def or class
+    rest = text[start:]
+    lines = rest.splitlines(True)
+    body = [lines[0]]
+    for line in lines[1:]:
+        if line.startswith("def ") or line.startswith("class ") or line.startswith("@"):
+            break
+        body.append(line)
+    ns: dict = {}
+    exec("".join(body), ns, ns)
+    return ns["_require_positive_timeout"]
+
+
+@pytest.fixture(scope="module")
+def require_positive_timeout():
+    return _load_helper()
+
+
+@pytest.mark.parametrize("bad", [0, -1, -0.5, 0.0])
+def test_action_timeout_rejects_non_positive(require_positive_timeout, bad):
+    with pytest.raises(ValueError, match="timeout_sec must be positive"):
+        require_positive_timeout(bad)
+
+
+def test_action_timeout_rejects_bool(require_positive_timeout):
+    with pytest.raises(TypeError, match="timeout_sec must be a positive number"):
+        require_positive_timeout(False)
+
+
+def test_action_timeout_accepts_positive(require_positive_timeout):
+    assert require_positive_timeout(1.0) == 1.0


### PR DESCRIPTION
## Summary
`ROS2ActionAPI.send_goal` now fails closed when `timeout_sec` is non-positive, a bool, or non-numeric — before `wait_for_server` / client construction.

Validation lives in a small module-local `_require_positive_timeout` next to the action API (keeps this PR path-orthogonal from the service helper).

## Test plan
- [x] Offline: `pytest tests/communication_offline/test_action_timeout_validate.py` (6 passed)
- [ ] CI green

AI-assisted; human-reviewed.