### PR TITLE
fix(tool_runner): avoid leaking tool exception details

### DIFF
--- a/src/rai_core/rai/agents/langchain/core/tool_runner.py
+++ b/src/rai_core/rai/agents/langchain/core/tool_runner.py
@@ -105,9 +105,15 @@ class ToolRunner(RunnableCallable):
                     status="error",
                 )
             except Exception as e:
-                self.logger.info(f'Error in "{call["name"]}", error: {e}')
+                # Log full details server-side; do not leak exception text to the LLM/user (CWE-209).
+                self.logger.exception(
+                    'Error in "%s"', call["name"]
+                )
                 output = ToolMessage(
-                    content=f"Failed to run tool. Error: {e}",
+                    content=(
+                        f"Tool '{call['name']}' failed with {type(e).__name__}. "
+                        "Please try again or rephrase your request."
+                    ),
                     name=call["name"],
                     tool_call_id=call["id"],
                     status="error",

--- a/tests/agents/langchain/test_tool_runner_cwe209.py
+++ b/tests/agents/langchain/test_tool_runner_cwe209.py
@@ -1,0 +1,90 @@
+# Copyright (C) 2026 Robotec.AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Offline regression tests for ToolRunner CWE-209 exception sanitization."""
+
+from logging import Logger
+from unittest.mock import MagicMock
+
+from langchain_core.messages import AIMessage, ToolMessage
+from langchain_core.tools import tool
+from rai.agents.langchain.core.tool_runner import ToolRunner
+
+
+@tool
+def leaky_tool(x: str) -> str:
+    """A tool that raises with a sensitive message."""
+    raise RuntimeError(
+        "DB connection failed: postgres://admin:SUPER_SECRET_PW@10.0.0.5:5432/prod"
+    )
+
+
+def test_tool_runner_does_not_leak_exception_details_to_llm():
+    logger = MagicMock(spec=Logger)
+    runner = ToolRunner(tools=[leaky_tool], logger=logger)
+    state = {
+        "messages": [
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "name": "leaky_tool",
+                        "args": {"x": "hi"},
+                        "id": "call_1",
+                        "type": "tool_call",
+                    }
+                ],
+            )
+        ]
+    }
+    result = runner.invoke(state)
+    msg = result["messages"][-1]
+    assert isinstance(msg, ToolMessage)
+    assert msg.status == "error"
+    content = msg.content
+    assert "SUPER_SECRET_PW" not in content
+    assert "10.0.0.5" not in content
+    assert "postgres://" not in content
+    assert "leaky_tool" in content
+    assert "RuntimeError" in content
+    logger.exception.assert_called()
+
+
+def test_tool_runner_success_path_unchanged():
+    @tool
+    def ok_tool(x: str) -> str:
+        """Return ok."""
+        return f"ok:{x}"
+
+    runner = ToolRunner(tools=[ok_tool], logger=MagicMock(spec=Logger))
+    state = {
+        "messages": [
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "name": "ok_tool",
+                        "args": {"x": "hi"},
+                        "id": "call_2",
+                        "type": "tool_call",
+                    }
+                ],
+            )
+        ]
+    }
+    result = runner.invoke(state)
+    msg = result["messages"][-1]
+    assert isinstance(msg, ToolMessage)
+    assert msg.status != "error"
+    assert "ok:hi" in str(msg.content)


### PR DESCRIPTION
## Summary

- Salvage of #814 by @sebastiondev (CWE-209: tool exception text leaked into `ToolMessage` returned to the LLM/user).
- Keep full diagnostics server-side via `logger.exception`.
- Return a generic message with tool name + exception **class name** only.
- **Value-add:** offline regression tests that prove secret/host strings never appear in `ToolMessage.content`.

## Credit

Original investigation, root-cause analysis, and fix approach by **@sebastiondev** in #814. This salvage rebases the intent onto current `main` and adds tests so the property stays locked.

## Motivation

Tool failures from DB/HTTP/SSH libraries often embed hosts, paths, and credentials in `str(e)`. Feeding that into `ToolMessage.content` surfaces internals to the LLM prompt and any conversation UI.

## Verification

```text
PYTHONPATH=src/rai_core python -m pytest tests/agents/langchain/test_tool_runner_cwe209.py -q
# 2 passed
```

- Did NOT change: ValidationError branch, success path, multimodal artifact handling.

## Notes for reviewers

Happy to close this in favor of #814 if preferred — the tests can be ported either direction.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h